### PR TITLE
fix/android ig stories sticker share

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -187,10 +187,6 @@ public abstract class ShareIntent {
                         try {
                             URL url = new URL(stickerSourceUrl);
                             String url_ext = "png";
-                            try {
-                                url_ext = stickerSourceUrl.substring(stickerSourceUrl.lastIndexOf(".") + 1);
-                            }
-                            catch (Exception e){}
                             Bitmap bitmap = BitmapFactory.decodeStream(url.openConnection().getInputStream());
                             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
                             bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream);


### PR DESCRIPTION
This fix allows the sticker image to be sent as a URL to the IG stories share (as used by us). 
The previous code was incorrectly dissecting the URL sent to try and get the file extension (when it will always be a png for our use). 